### PR TITLE
feat(views): add customizable element IDs for update views

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -122,6 +122,64 @@ Your detail template must include an ID that matches your model instance:
 
 This ID is used to update the content after successful form submission.
 
+## Customizing Element IDs
+
+By default, the update view uses the pattern `{model_name}-{pk}` for element IDs (e.g., `person-1`). You can customize this behavior in several ways:
+
+### Using Prefixes and Suffixes
+
+For simple customization, use `element_id_prefix` or `element_id_suffix`:
+
+```python
+class BasicInfoUpdateView(HtmxModalUpdateView):
+    model = Person
+    form_class = BasicInfoForm
+    detail_template_name = "persons/_basic_info.html"
+    element_id_prefix = "basic-"  # Results in "basic-person-1"
+
+class ContactUpdateView(HtmxModalUpdateView):
+    model = Person
+    form_class = ContactForm
+    detail_template_name = "persons/_contact.html"
+    element_id_suffix = "-contact"  # Results in "person-1-contact"
+```
+
+### Custom ID Generation
+
+For more complex patterns, override the `get_element_id` method:
+
+```python
+class CustomPersonUpdateView(HtmxModalUpdateView):
+    model = Person
+    form_class = PersonForm
+    detail_template_name = "persons/_person.html"
+
+    def get_element_id(self) -> str:
+        """Generate a custom element ID."""
+        return f"person-{self.object.type}-{self.object.pk}"
+```
+
+Make sure your detail templates use matching IDs:
+
+```html
+<!-- With prefix -->
+<div id="basic-person-{{ person.id }}" class="card">
+  <!-- content -->
+</div>
+
+<!-- With suffix -->
+<div id="person-{{ person.id }}-contact" class="card">
+  <!-- content -->
+</div>
+
+<!-- With custom pattern -->
+<div id="person-{{ person.type }}-{{ person.id }}" class="card">
+  <!-- content -->
+</div>
+```
+
+This is particularly useful when you need multiple forms targeting different parts of the same model on a single page.
+
 ## Error Handling
 
 Form validation errors are automatically handled:

--- a/src/django_htmx_modal_forms/views.py
+++ b/src/django_htmx_modal_forms/views.py
@@ -35,6 +35,8 @@ class HtmxModalFormMixin(View):
     form_template_name = "htmx_modal_forms/_form_content.html"
     modal_size: str = "lg"
     modal_title: Optional[str] = None
+    element_id_prefix: Optional[str] = None
+    element_id_suffix: Optional[str] = None
 
     def get(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse:
         """Handle GET requests and trigger modal show."""
@@ -60,6 +62,18 @@ class HtmxModalFormMixin(View):
         Override this method to customize the modal size.
         """
         return self.modal_size
+
+    def get_element_id(self) -> str:
+        """
+        Get the element ID for the form target.
+
+        This method can be overridden to customize the ID generation.
+        By default, it uses the pattern: "{prefix}{model_name}-{pk}{suffix}"
+        """
+        prefix = self.element_id_prefix or ""
+        suffix = self.element_id_suffix or ""
+        base_id = f"{self.model._meta.model_name}-{self.object.pk}"
+        return f"{prefix}{base_id}{suffix}"
 
     def get_context_data(self, **kwargs: Any) -> dict[str, Any]:
         """Add modal-specific context."""
@@ -132,7 +146,7 @@ class HtmxModalUpdateView(HtmxModalFormMixin, UpdateView):
         # Create response with out-of-band swap
         response = HttpResponse(
             f"""
-            <div id="{self.model._meta.model_name}-{self.object.pk}"
+            <div id="{self.get_element_id()}"
                  hx-swap-oob="true">
                 {detail_html}
             </div>


### PR DESCRIPTION
Allow users to customize HTML element IDs in update views by:
- Adding element_id_prefix and element_id_suffix class attributes
- Adding get_element_id() method for custom ID generation logic
- Enabling support for multiple forms targeting the same model

This helps when multiple update forms for a single model need to target different elements on the page.

<!--
  😀 Wonderful!  Thank you for opening a pull request.

  By submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/abe-101/django-htmx-modal-forms/blob/main/.github/CODE_OF_CONDUCT.md).

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following to merge this PR.

  Note that there is no problem if they are not checked when this PR is created.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `main` branch
- [x] This pull request follows the [contributing guidelines](https://github.com/abe-101/django-htmx-modal-forms/blob/main/CONTRIBUTING.md).
- [x] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests".

> - If pre-commit.ci is failing, try `pre-commit run -a` for further information.
> - If CI / test is failing, try `uv run pytest` for further information.

<!--
  🎉 Thank you for contributing!
-->
